### PR TITLE
Fix #6097: the keyword IDs are not escaped qthelp in .qhp file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Release 1.0.2 (2019-02-24)
+==========================
+
+* #6097: the keyword IDs are not escaped qthelp in .qhp file
+
 Release 1.0.1 (2019-02-15)
 ==========================
 

--- a/sphinxcontrib/qthelp/__init__.py
+++ b/sphinxcontrib/qthelp/__init__.py
@@ -203,7 +203,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
             # descr = groupdict.get('descr')
             if shortname.endswith('()'):
                 shortname = shortname[:-2]
-            id = '%s.%s' % (id, shortname)
+            id = html.escape('%s.%s' % (id, shortname), True)
         else:
             id = None
 

--- a/tests/roots/test-need-escaped/index.rst
+++ b/tests/roots/test-need-escaped/index.rst
@@ -24,6 +24,9 @@ Contents:
    single: & (ampersand)
    single: < (less)
    single: > (greater)
+   single: Sphinx (document generator)
+   single: keyword1 (class in ID)
+   single: keyword2 (foo bar baz)
 
 ----------
 subsection

--- a/tests/roots/test-need-escaped/index.rst
+++ b/tests/roots/test-need-escaped/index.rst
@@ -21,6 +21,9 @@ Contents:
 
 .. index::
    pair: "subsection"; <subsection>
+   single: & (ampersand)
+   single: < (less)
+   single: > (greater)
 
 ----------
 subsection

--- a/tests/test_qthelp.py
+++ b/tests/test_qthelp.py
@@ -62,9 +62,20 @@ def test_qthelp_escaped(app, status, warning):
     assert toc[0][3].attrib == {'title': 'baz', 'ref': 'baz.html'}
 
     keywords = et.find('.//keywords')
-    assert len(keywords) == 2
-    assert keywords[0].attrib == {'name': '<subsection>', 'ref': 'index.html#index-0'}
-    assert keywords[1].attrib == {'name': '"subsection"', 'ref': 'index.html#index-0'}
+    assert len(keywords) == 5
+    assert keywords[0].attrib == {'name': '<subsection>',
+                                  'ref': 'index.html#index-0'}
+    assert keywords[1].attrib == {'name': '& (ampersand)',
+                                  'id': 'ampersand.&',
+                                  'ref': 'index.html#index-0'}
+    assert keywords[2].attrib == {'name': '< (less)',
+                                  'id': 'less.<',
+                                  'ref': 'index.html#index-0'}
+    assert keywords[3].attrib == {'name': '"subsection"',
+                                  'ref': 'index.html#index-0'}
+    assert keywords[4].attrib == {'name': '> (greater)',
+                                  'id': 'greater.>',
+                                  'ref': 'index.html#index-0'}
 
 
 @pytest.mark.sphinx('qthelp', testroot='basic')

--- a/tests/test_qthelp.py
+++ b/tests/test_qthelp.py
@@ -62,7 +62,7 @@ def test_qthelp_escaped(app, status, warning):
     assert toc[0][3].attrib == {'title': 'baz', 'ref': 'baz.html'}
 
     keywords = et.find('.//keywords')
-    assert len(keywords) == 5
+    assert len(keywords) == 8
     assert keywords[0].attrib == {'name': '<subsection>',
                                   'ref': 'index.html#index-0'}
     assert keywords[1].attrib == {'name': '& (ampersand)',
@@ -75,6 +75,14 @@ def test_qthelp_escaped(app, status, warning):
                                   'ref': 'index.html#index-0'}
     assert keywords[4].attrib == {'name': '> (greater)',
                                   'id': 'greater.>',
+                                  'ref': 'index.html#index-0'}
+    assert keywords[5].attrib == {'name': 'keyword1 (class in ID)',
+                                  'id': 'ID.keyword1',
+                                  'ref': 'index.html#index-0'}
+    assert keywords[6].attrib == {'name': 'keyword2 (foo bar baz)',
+                                  'ref': 'index.html#index-0'}
+    assert keywords[7].attrib == {'name': 'Sphinx (document generator)',
+                                  'id': 'document.Sphinx',
                                   'ref': 'index.html#index-0'}
 
 


### PR DESCRIPTION
refs: https://github.com/sphinx-doc/sphinx/issues/6097