### PR TITLE
Use out_suffix/link_suffix for index document

### DIFF
--- a/sphinxcontrib/qthelp/__init__.py
+++ b/sphinxcontrib/qthelp/__init__.py
@@ -86,6 +86,11 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
         return self.config.qthelp_theme, self.config.qthelp_theme_options
 
     def handle_finish(self) -> None:
+        if self.config.qthelp_basename != self.config.project:
+            self.epilog = self.epilog % {
+                'outdir': '%(outdir)s',
+                'project': self.config.qthelp_basename,
+            }
         self.build_qhp(self.outdir, self.config.qthelp_basename)
 
     def build_qhp(self, outdir: str, outname: str) -> None:

--- a/sphinxcontrib/qthelp/__init__.py
+++ b/sphinxcontrib/qthelp/__init__.py
@@ -102,7 +102,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
 
         for indexname, indexcls, content, collapse in self.domain_indices:
             item = section_template % {'title': indexcls.localname,
-                                       'ref': '%s.html' % indexname}
+                                       'ref': ''.join((indexname, self.out_suffix))}
             sections.append(' ' * 4 * 4 + item)
         sections = '\n'.join(sections)  # type: ignore
 
@@ -138,7 +138,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
 
         homepage = 'qthelp://' + posixpath.join(
             nspace, 'doc', self.get_target_uri(self.config.master_doc))
-        startpage = 'qthelp://' + posixpath.join(nspace, 'doc', 'index.html')
+        startpage = 'qthelp://' + posixpath.join(nspace, 'doc', 'index%s' % self.link_suffix)
 
         logger.info(__('writing collection project file...'))
         with open(path.join(outdir, outname + '.qhcp'), 'w', encoding='utf-8') as f:

--- a/sphinxcontrib/qthelp/__init__.py
+++ b/sphinxcontrib/qthelp/__init__.py
@@ -107,7 +107,7 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
 
         for indexname, indexcls, content, collapse in self.domain_indices:
             item = section_template % {'title': indexcls.localname,
-                                       'ref': ''.join((indexname, self.out_suffix))}
+                                       'ref': indexname + self.out_suffix}
             sections.append(' ' * 4 * 4 + item)
         sections = '\n'.join(sections)  # type: ignore
 


### PR DESCRIPTION
Background: I'm trying to generate qthelp files for multiple languages. The only way to do this is probably to generate a qhc file for each language. However, this makes the file size *very large* when shipping all those files with the application, because all static content (images, etc.) are duplicated multiple times.

Therefore I'd like to hack around it by subclassing the QtHelp builder and using language-dependent suffixes (e.g. `*.en-US.html`), then generating a custom qhp that includes all languages and use filters to switch between them. While working on this, I stumbled over this issue.