### PR TITLE
CI: Do not test with python3.5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
       max-parallel: 1
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 skip_missing_interpreters = true
-envlist=flake8,mypy,py35,py36,py37,py38,py39,py310-dev
+envlist=flake8,mypy,py36,py37,py38,py39,py310-dev
 
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38


### PR DESCRIPTION
Sphinx-4.0 will be drop the support of python3.5. So this also stops it on CI